### PR TITLE
Support minimized windows on Windows.

### DIFF
--- a/GotoWindow.py
+++ b/GotoWindow.py
@@ -102,7 +102,7 @@ class GotoWindowCommand(sublime_plugin.WindowCommand):
         # supported by Applescript.
         cmd = """
             tell application "System Events"
-                activate application "Dock"
+                activate application "Finder"
                 delay 1/60
                 activate application "%s"
             end tell""" % name


### PR DESCRIPTION
This will restore a minimized window on Windows.  It should work on all versions of Windows (these are ancient APIs), but I only have 64-bit Windows 10 handy to test.

I spent some time trying to figure out a way to get the equivalent to work on Mac.  The only method I found is awkward and requires adding permissions in the System Preferences.  Not sure if you have any thoughts about that.  I wish things would just be fixed within Sublime.

I tried to keep this patch small, but it does add a fair amount of platform-specific code.