### PR TITLE
Added options to use workspace name instead of project name

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,45 @@
+[
+    {
+        "id": "preferences",
+        "children": [
+            {
+                "caption": "Package Settings",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption":"GotoWindow",
+                        "children":
+                        [
+                            {
+                                "caption": "Settings - Default",
+                                "command": "open_file",
+                                "args": {"file": "${packages}/GotoWindow/goto_window.sublime-settings"}
+                            },
+                            {
+                                "caption": "Settings - User",
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/goto_window.sublime-settings"}
+                            },
+                            {
+                                "caption":"-"
+                            },
+                            {
+                                "caption": "Key Bindings - Default",
+                                "command": "open_file",
+                                "args": {"file": "${packages}/GotoWindow/Default ($platform).sublime-keymap"}
+                            },
+                            {
+                                "caption": "Key Bindings - User",
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/Default ($platform).sublime-keymap"}
+                            },
+
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+]

--- a/goto_window.sublime-settings
+++ b/goto_window.sublime-settings
@@ -1,0 +1,6 @@
+{
+    // Use to set window name as either 
+    //    "project"   : For project name
+    //    "workspace" : For workspace name
+    "window-name": "project"
+}


### PR DESCRIPTION
Hi! Big fan of this plugin. 

I found it doesn't work well if you use different sublime-workspaces within the same sublime-project. In that case, you will see several windows with the same (project) name.

I changed it around a bit to allow either workspace or project names depending on a user specified option, which can be found under SublimeText -> Preferences -> PackageSettings -> GotoWindow. This only works in sublime-text 4, for which the api allows window.workspace_file_name(). 

Not sure if you'd like to use this functionality or maybe edit it around a bit, but could be helpful for others. 